### PR TITLE
fixed inconsistent gd-number arg handling in tags

### DIFF
--- a/tools/scripts/calculate_tags.py
+++ b/tools/scripts/calculate_tags.py
@@ -574,7 +574,7 @@ def main(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Analyze Remesh tag data for Global Dialogues.")
-    parser.add_argument("gd_number", type=int, help="Global Dialogue cadence number (e.g., 3).")
+    parser.add_argument("--gd_number", type=int, help="Global Dialogue cadence number (e.g., 3).")
     # Add other arguments as needed (e.g., input/output directory overrides)
 
     args = parser.parse_args()


### PR DESCRIPTION
@evanhadfield I was unable to build on a fresh install. I think this was caused by an inconsistency in the way the gd-number arg is handled between calculate tags and the other files.

Error:
```
2025-05-27 10:03:20,965 - INFO - --- Running calculate_tags.py for GD3 --- 
2025-05-27 10:03:20,965 - INFO - Executing: /Users/brandonjackson/miniconda3/bin/python tools/scripts/calculate_tags.py --gd_number 3
2025-05-27 10:03:21,329 - ERROR - --- calculate_tags.py failed (exit code 2) ---
2025-05-27 10:03:21,329 - ERROR - Command: /Users/brandonjackson/miniconda3/bin/python tools/scripts/calculate_tags.py --gd_number 3
2025-05-27 10:03:21,329 - ERROR - Stderr:
usage: calculate_tags.py [-h] gd_number
calculate_tags.py: error: unrecognized arguments: --gd_number

2025-05-27 10:03:21,329 - ERROR - Stdout:

2025-05-27 10:03:21,329 - ERROR - Pipeline stopped due to failure in calculate_tags.py.
2025-05-27 10:03:21,329 - WARNING - Analysis pipeline for GD3 completed with errors.
make: *** [analyze-gd3] Error 1
```